### PR TITLE
[ADD] xml version 1.0

### DIFF
--- a/snippets/xml.json
+++ b/snippets/xml.json
@@ -406,6 +406,7 @@
     "odoo_data": {
         "prefix": "odata",
         "body": [
+            "<?xml version='1.0' encoding='utf-8'?>",
             "<odoo>",
             "\t<data noupdate=\"${1:1}\"/>",
             "\t\t<!-- Add you code here -->",


### PR DESCRIPTION
Hi, 
In first , a lot of thanks for this pluggin for vcode. It's very helpfull.

I think it's usefull add this line, "<?xml version="1.0" encoding="utf-8"?>", because is necesary in a xml type file and when I use "odata" snip, it's because the file is new and it's empty, without this line.